### PR TITLE
Update phalcon3.4

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -2,7 +2,7 @@ FROM php:5.5
 
 LABEL maintainer="MilesChou <github.com/MilesChou>, fizzka <github.com/fizzka>"
 
-ARG PHALCON_VERSION=3.3.1
+ARG PHALCON_VERSION=3.4.0
 ARG PHALCON_EXT_PATH=php5/64bits
 
 RUN set -xe && \

--- a/5.5/alpine/Dockerfile
+++ b/5.5/alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM php:5.5-alpine
 
 LABEL maintainer="MilesChou <github.com/MilesChou>, fizzka <github.com/fizzka>"
 
-ARG PHALCON_VERSION=3.3.1
+ARG PHALCON_VERSION=3.4.0
 ARG PHALCON_EXT_PATH=php5/64bits
 
 RUN set -xe && \

--- a/5.5/apache/Dockerfile
+++ b/5.5/apache/Dockerfile
@@ -2,7 +2,7 @@ FROM php:5.5-apache
 
 LABEL maintainer="MilesChou <github.com/MilesChou>, fizzka <github.com/fizzka>"
 
-ARG PHALCON_VERSION=3.3.1
+ARG PHALCON_VERSION=3.4.0
 ARG PHALCON_EXT_PATH=php5/64bits
 
 RUN set -xe && \

--- a/5.5/fpm/Dockerfile
+++ b/5.5/fpm/Dockerfile
@@ -2,7 +2,7 @@ FROM php:5.5-fpm
 
 LABEL maintainer="MilesChou <github.com/MilesChou>, fizzka <github.com/fizzka>"
 
-ARG PHALCON_VERSION=3.3.1
+ARG PHALCON_VERSION=3.4.0
 ARG PHALCON_EXT_PATH=php5/64bits
 
 RUN set -xe && \

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -2,7 +2,7 @@ FROM php:5.6
 
 LABEL maintainer="MilesChou <github.com/MilesChou>, fizzka <github.com/fizzka>"
 
-ARG PHALCON_VERSION=3.3.1
+ARG PHALCON_VERSION=3.4.0
 ARG PHALCON_EXT_PATH=php5/64bits
 
 RUN set -xe && \

--- a/5.6/alpine/Dockerfile
+++ b/5.6/alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM php:5.6-alpine
 
 LABEL maintainer="MilesChou <github.com/MilesChou>, fizzka <github.com/fizzka>"
 
-ARG PHALCON_VERSION=3.3.1
+ARG PHALCON_VERSION=3.4.0
 ARG PHALCON_EXT_PATH=php5/64bits
 
 RUN set -xe && \

--- a/5.6/apache/Dockerfile
+++ b/5.6/apache/Dockerfile
@@ -2,7 +2,7 @@ FROM php:5.6-apache
 
 LABEL maintainer="MilesChou <github.com/MilesChou>, fizzka <github.com/fizzka>"
 
-ARG PHALCON_VERSION=3.3.1
+ARG PHALCON_VERSION=3.4.0
 ARG PHALCON_EXT_PATH=php5/64bits
 
 RUN set -xe && \

--- a/5.6/fpm/Dockerfile
+++ b/5.6/fpm/Dockerfile
@@ -2,7 +2,7 @@ FROM php:5.6-fpm
 
 LABEL maintainer="MilesChou <github.com/MilesChou>, fizzka <github.com/fizzka>"
 
-ARG PHALCON_VERSION=3.3.1
+ARG PHALCON_VERSION=3.4.0
 ARG PHALCON_EXT_PATH=php5/64bits
 
 RUN set -xe && \

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -2,7 +2,7 @@ FROM php:7.0
 
 LABEL maintainer="MilesChou <github.com/MilesChou>, fizzka <github.com/fizzka>"
 
-ARG PHALCON_VERSION=3.3.1
+ARG PHALCON_VERSION=3.4.0
 ARG PHALCON_EXT_PATH=php7/64bits
 
 RUN set -xe && \

--- a/7.0/alpine/Dockerfile
+++ b/7.0/alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM php:7.0-alpine
 
 LABEL maintainer="MilesChou <github.com/MilesChou>, fizzka <github.com/fizzka>"
 
-ARG PHALCON_VERSION=3.3.1
+ARG PHALCON_VERSION=3.4.0
 ARG PHALCON_EXT_PATH=php7/64bits
 
 RUN set -xe && \

--- a/7.0/apache/Dockerfile
+++ b/7.0/apache/Dockerfile
@@ -2,7 +2,7 @@ FROM php:7.0-apache
 
 LABEL maintainer="MilesChou <github.com/MilesChou>, fizzka <github.com/fizzka>"
 
-ARG PHALCON_VERSION=3.3.1
+ARG PHALCON_VERSION=3.4.0
 ARG PHALCON_EXT_PATH=php7/64bits
 
 RUN set -xe && \

--- a/7.0/fpm-alpine/Dockerfile
+++ b/7.0/fpm-alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM php:7.0-fpm-alpine
 
 LABEL maintainer="MilesChou <github.com/MilesChou>, fizzka <github.com/fizzka>"
 
-ARG PHALCON_VERSION=3.3.1
+ARG PHALCON_VERSION=3.4.0
 ARG PHALCON_EXT_PATH=php7/64bits
 
 RUN set -xe && \

--- a/7.0/fpm/Dockerfile
+++ b/7.0/fpm/Dockerfile
@@ -2,7 +2,7 @@ FROM php:7.0-fpm
 
 LABEL maintainer="MilesChou <github.com/MilesChou>, fizzka <github.com/fizzka>"
 
-ARG PHALCON_VERSION=3.3.1
+ARG PHALCON_VERSION=3.4.0
 ARG PHALCON_EXT_PATH=php7/64bits
 
 RUN set -xe && \

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -2,7 +2,7 @@ FROM php:7.1
 
 LABEL maintainer="MilesChou <github.com/MilesChou>, fizzka <github.com/fizzka>"
 
-ARG PHALCON_VERSION=3.3.1
+ARG PHALCON_VERSION=3.4.0
 ARG PHALCON_EXT_PATH=php7/64bits
 
 RUN set -xe && \

--- a/7.1/alpine/Dockerfile
+++ b/7.1/alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM php:7.1-alpine
 
 LABEL maintainer="MilesChou <github.com/MilesChou>, fizzka <github.com/fizzka>"
 
-ARG PHALCON_VERSION=3.3.1
+ARG PHALCON_VERSION=3.4.0
 ARG PHALCON_EXT_PATH=php7/64bits
 
 RUN set -xe && \

--- a/7.1/apache/Dockerfile
+++ b/7.1/apache/Dockerfile
@@ -2,7 +2,7 @@ FROM php:7.1-apache
 
 LABEL maintainer="MilesChou <github.com/MilesChou>, fizzka <github.com/fizzka>"
 
-ARG PHALCON_VERSION=3.3.1
+ARG PHALCON_VERSION=3.4.0
 ARG PHALCON_EXT_PATH=php7/64bits
 
 RUN set -xe && \

--- a/7.1/fpm-alpine/Dockerfile
+++ b/7.1/fpm-alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM php:7.1-fpm-alpine
 
 LABEL maintainer="MilesChou <github.com/MilesChou>, fizzka <github.com/fizzka>"
 
-ARG PHALCON_VERSION=3.3.1
+ARG PHALCON_VERSION=3.4.0
 ARG PHALCON_EXT_PATH=php7/64bits
 
 RUN set -xe && \

--- a/7.1/fpm/Dockerfile
+++ b/7.1/fpm/Dockerfile
@@ -2,7 +2,7 @@ FROM php:7.1-fpm
 
 LABEL maintainer="MilesChou <github.com/MilesChou>, fizzka <github.com/fizzka>"
 
-ARG PHALCON_VERSION=3.3.1
+ARG PHALCON_VERSION=3.4.0
 ARG PHALCON_EXT_PATH=php7/64bits
 
 RUN set -xe && \

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -2,7 +2,7 @@ FROM php:7.2
 
 LABEL maintainer="MilesChou <github.com/MilesChou>, fizzka <github.com/fizzka>"
 
-ARG PHALCON_VERSION=3.3.1
+ARG PHALCON_VERSION=3.4.0
 ARG PHALCON_EXT_PATH=php7/64bits
 
 RUN set -xe && \

--- a/7.2/alpine/Dockerfile
+++ b/7.2/alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM php:7.2-alpine
 
 LABEL maintainer="MilesChou <github.com/MilesChou>, fizzka <github.com/fizzka>"
 
-ARG PHALCON_VERSION=3.3.1
+ARG PHALCON_VERSION=3.4.0
 ARG PHALCON_EXT_PATH=php7/64bits
 
 RUN set -xe && \

--- a/7.2/apache/Dockerfile
+++ b/7.2/apache/Dockerfile
@@ -2,7 +2,7 @@ FROM php:7.2-apache
 
 LABEL maintainer="MilesChou <github.com/MilesChou>, fizzka <github.com/fizzka>"
 
-ARG PHALCON_VERSION=3.3.1
+ARG PHALCON_VERSION=3.4.0
 ARG PHALCON_EXT_PATH=php7/64bits
 
 RUN set -xe && \

--- a/7.2/fpm-alpine/Dockerfile
+++ b/7.2/fpm-alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM php:7.2-fpm-alpine
 
 LABEL maintainer="MilesChou <github.com/MilesChou>, fizzka <github.com/fizzka>"
 
-ARG PHALCON_VERSION=3.3.1
+ARG PHALCON_VERSION=3.4.0
 ARG PHALCON_EXT_PATH=php7/64bits
 
 RUN set -xe && \

--- a/7.2/fpm/Dockerfile
+++ b/7.2/fpm/Dockerfile
@@ -2,7 +2,7 @@ FROM php:7.2-fpm
 
 LABEL maintainer="MilesChou <github.com/MilesChou>, fizzka <github.com/fizzka>"
 
-ARG PHALCON_VERSION=3.3.1
+ARG PHALCON_VERSION=3.4.0
 ARG PHALCON_EXT_PATH=php7/64bits
 
 RUN set -xe && \

--- a/Makefile
+++ b/Makefile
@@ -44,12 +44,12 @@ push:
 	docker push -t=$(IMAGE):7.1-alpine
 	docker push -t=$(IMAGE):7.1-apache
 	docker push -t=$(IMAGE):7.1-fpm
-        docker push -t=$(IMAGE):7.1-fpm-alpine
+	docker push -t=$(IMAGE):7.1-fpm-alpine
 	docker push -t=$(IMAGE):7.0
 	docker push -t=$(IMAGE):7.0-alpine
 	docker push -t=$(IMAGE):7.0-apache
 	docker push -t=$(IMAGE):7.0-fpm
-        docker push -t=$(IMAGE):7.0-fpm-alpine
+	docker push -t=$(IMAGE):7.0-fpm-alpine
 	docker push -t=$(IMAGE):5.6
 	docker push -t=$(IMAGE):5.6-alpine
 	docker push -t=$(IMAGE):5.6-apache

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 IMAGE := mileschou/phalcon
 VERSION := 3.4.0
-DEVTOOLS_VERSION := 3.2.12
+DEVTOOLS_VERSION := 3.2.13
 
 .PHONY: all build push update variants clean
 

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ push:
 
 update:
 	@echo Update Phalcon version to $(VERSION) ...
-	@find */**/Dockerfile */Dockerfile -exec sed -i 's/^ENV PHALCON_VERSION=.*/ENV PHALCON_VERSION=$(VERSION)/g' {} +;
+	@find */**/Dockerfile */Dockerfile -exec sed -i 's/^ARG PHALCON_VERSION=.*/ARG PHALCON_VERSION=$(VERSION)/g' {} +;
 	@sed -i 's/^VERSION := .*/VERSION := $(VERSION)/g' Makefile
 	@# shields
 	@sed -i 's/Phalcon-[^-]*/Phalcon-$(VERSION)/g' README.md

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 IMAGE := mileschou/phalcon
-VERSION := 3.3.1
+VERSION := 3.4.0
 DEVTOOLS_VERSION := 3.2.12
 
 .PHONY: all build push update variants clean

--- a/Makefile
+++ b/Makefile
@@ -10,29 +10,29 @@ DEVTOOLS_VERSION := 3.2.13
 all: build
 
 build: update
-	docker build -t=$(IMAGE):7.2 7.2
-	docker build -t=$(IMAGE):7.2-alpine 7.2/alpine
-	docker build -t=$(IMAGE):7.2-apache 7.2/apache
-	docker build -t=$(IMAGE):7.2-fpm 7.2/fpm
-	docker build -t=$(IMAGE):7.2-fpm-alpine 7.2/fpm-alpine
-	docker build -t=$(IMAGE):7.1 7.1
-	docker build -t=$(IMAGE):7.1-alpine 7.1/alpine
-	docker build -t=$(IMAGE):7.1-apache 7.1/apache
-	docker build -t=$(IMAGE):7.1-fpm 7.1/fpm
-	docker build -t=$(IMAGE):7.1-fpm-alpine 7.1/fpm-alpine
-	docker build -t=$(IMAGE):7.0 7.0
-	docker build -t=$(IMAGE):7.0-alpine 7.0/alpine
-	docker build -t=$(IMAGE):7.0-apache 7.0/apache
-	docker build -t=$(IMAGE):7.0-fpm 7.0/fpm
-	docker build -t=$(IMAGE):7.0-fpm-alpine 7.0/fpm-alpine
-	docker build -t=$(IMAGE):5.6 5.6
-	docker build -t=$(IMAGE):5.6-alpine 5.6/alpine
-	docker build -t=$(IMAGE):5.6-apache 5.6/apache
-	docker build -t=$(IMAGE):5.6-fpm 5.6/fpm
-	docker build -t=$(IMAGE):5.5 5.5
-	docker build -t=$(IMAGE):5.5-alpine 5.5/alpine
-	docker build -t=$(IMAGE):5.5-apache 5.5/apache
-	docker build -t=$(IMAGE):5.5-fpm 5.5/fpm
+	docker build -t=$(IMAGE):7.2 -f 7.2/Dockerfile .
+	docker build -t=$(IMAGE):7.2-alpine -f 7.2/alpine/Dockerfile .
+	docker build -t=$(IMAGE):7.2-apache -f 7.2/apache/Dockerfile .
+	docker build -t=$(IMAGE):7.2-fpm -f 7.2/fpm/Dockerfile .
+	docker build -t=$(IMAGE):7.2-fpm -f-alpine 7.2/fpm-alpine/Dockerfile .
+	docker build -t=$(IMAGE):7.1 7 -f.1/Dockerfile .
+	docker build -t=$(IMAGE):7.1-alpine -f 7.1/alpine/Dockerfile .
+	docker build -t=$(IMAGE):7.1-apache -f 7.1/apache/Dockerfile .
+	docker build -t=$(IMAGE):7.1-fpm -f 7.1/fpm/Dockerfile .
+	docker build -t=$(IMAGE):7.1-fpm -f-alpine 7.1/fpm-alpine/Dockerfile .
+	docker build -t=$(IMAGE):7.0 7 -f.0/Dockerfile .
+	docker build -t=$(IMAGE):7.0-alpine -f 7.0/alpine/Dockerfile .
+	docker build -t=$(IMAGE):7.0-apache -f 7.0/apache/Dockerfile .
+	docker build -t=$(IMAGE):7.0-fpm -f 7.0/fpm/Dockerfile .
+	docker build -t=$(IMAGE):7.0-fpm -f-alpine 7.0/fpm-alpine/Dockerfile .
+	docker build -t=$(IMAGE):5.6 5 -f.6/Dockerfile .
+	docker build -t=$(IMAGE):5.6-alpine -f 5.6/alpine/Dockerfile .
+	docker build -t=$(IMAGE):5.6-apache -f 5.6/apache/Dockerfile .
+	docker build -t=$(IMAGE):5.6-fpm -f 5.6/fpm/Dockerfile .
+	docker build -t=$(IMAGE):5.5 5 -f.5/Dockerfile .
+	docker build -t=$(IMAGE):5.5-alpine -f 5.5/alpine/Dockerfile .
+	docker build -t=$(IMAGE):5.5-apache -f 5.5/apache/Dockerfile .
+	docker build -t=$(IMAGE):5.5-fpm -f 5.5/fpm/Dockerfile .
 
 push:
 	docker push -t=$(IMAGE):7.2

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ update:
 	@# readme test version
 	@sed -i 's/Version => .*/Version => $(VERSION)/g' README.md
 	@echo Update Phalcon-devtools version to $(DEVTOOLS_VERSION) ...
-	@find */**/Dockerfile */Dockerfile -exec sed -i 's/^ENV PHALCON_DEV_TOOLS_VERSION=.*/ENV PHALCON_DEV_TOOLS_VERSION=$(DEVTOOLS_VERSION)/g' {} +;
+	@find docker-phalcon-install-devtools -exec sed -i 's/^INSTALL_VERSION=.*/INSTALL_VERSION=$(DEVTOOLS_VERSION)/g' {} +;
 	@sed -i 's/^DEVTOOLS_VERSION := .*/DEVTOOLS_VERSION := $(DEVTOOLS_VERSION)/g' Makefile
 	@# shields
 	@sed -i 's/phalcon--devtools-[^-]*/phalcon--devtools-$(DEVTOOLS_VERSION)/g' README.md

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Docker Phalcon
 
 ![Phalcon Version](https://img.shields.io/badge/Phalcon-3.4.0-blue.svg)
-![Phalcon devtools](https://img.shields.io/badge/phalcon--devtools-3.2.12-blue.svg)
+![Phalcon devtools](https://img.shields.io/badge/phalcon--devtools-3.2.13-blue.svg)
 [![Build Status](https://travis-ci.org/MilesChou/docker-phalcon.svg?branch=master)](https://travis-ci.org/MilesChou/docker-phalcon)
 [![](https://images.microbadger.com/badges/version/mileschou/phalcon:alpine.svg)](http://microbadger.com/images/mileschou/phalcon:alpine "Get your own version badge on microbadger.com")
 [![](https://images.microbadger.com/badges/image/mileschou/phalcon:alpine.svg)](http://microbadger.com/images/mileschou/phalcon:alpine "Get your own image badge on microbadger.com")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Docker Phalcon
 
-![Phalcon Version](https://img.shields.io/badge/Phalcon-3.3.1-blue.svg)
+![Phalcon Version](https://img.shields.io/badge/Phalcon-3.4.0-blue.svg)
 ![Phalcon devtools](https://img.shields.io/badge/phalcon--devtools-3.2.12-blue.svg)
 [![Build Status](https://travis-ci.org/MilesChou/docker-phalcon.svg?branch=master)](https://travis-ci.org/MilesChou/docker-phalcon)
 [![](https://images.microbadger.com/badges/version/mileschou/phalcon:alpine.svg)](http://microbadger.com/images/mileschou/phalcon:alpine "Get your own version badge on microbadger.com")
@@ -10,7 +10,7 @@
 
 Docker Phalcon base image, see https://hub.docker.com/r/mileschou/phalcon/
 
-The repository is a Docker image based on [Docker official PHP image](https://hub.docker.com/_/php/) with [Phalcon Framework](https://phalconphp.com/) Version 3.2+.
+The repository is a Docker image based on [Docker official PHP image](https://hub.docker.com/_/php/) with [Phalcon Framework](https://phalconphp.com/) Version 3.4+.
 
 ## Supported tags and respective `Dockerfile` links
 
@@ -43,7 +43,7 @@ The repository is a Docker image based on [Docker official PHP image](https://hu
 Here is a simple test command that can confirm the extension has been loaded.
 
     $ docker run -it --rm mileschou/phalcon php --ri phalcon | grep -i ^version
-    Version => 3.3.1
+    Version => 3.4.0
 
 ## Builded Image included simple script `docker-phalcon-install-devtools` to install latest release of Phalcon Devtools CLI
 

--- a/docker-phalcon-install-devtools
+++ b/docker-phalcon-install-devtools
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-INSTALL_VERSION=3.2.12
+INSTALL_VERSION=3.2.13
 
 if [ "$1" != "" ]; then
     INSTALL_VERSION=$1


### PR DESCRIPTION
```
$ phalcon -v

Phalcon DevTools (3.2.13)

Environment:
  OS: Linux 5395d75c76dc 4.4.0-127-generic #153-Ubuntu SMP Sat May 19 10:58:46 UTC 2018 x86_64
  PHP Version: 7.2.6
  PHP SAPI: cli
  PHP Bin: /usr/local/bin/php
  PHP Extension Dir: /usr/local/lib/php/extensions/no-debug-non-zts-20170718
  PHP Bin Dir: /usr/local/bin
  Loaded PHP config:
Versions:
  Phalcon DevTools Version: 3.2.13
  Phalcon Version: 3.4.0
  AdminLTE Version: 2.3.6
