### PR TITLE
phalcon: command not found after the install

### DIFF
--- a/docker-phalcon-install-devtools
+++ b/docker-phalcon-install-devtools
@@ -11,4 +11,4 @@ curl -LO https://github.com/phalcon/phalcon-devtools/archive/v${INSTALL_VERSION}
 tar xzf v${INSTALL_VERSION}.tar.gz
 rm -rf v${INSTALL_VERSION}.tar.gz
 mv phalcon-devtools-${INSTALL_VERSION} /usr/src/phalcon-devtools
-ln -sf /usr/src/phalcon-devtools/phalcon.php /usr/local/bin/phalcon
+ln -sf /usr/src/phalcon-devtools/phalcon /usr/local/bin/phalcon


### PR DESCRIPTION
I had "phalcon: command not found" after using "sh -c usr/local/bin/docker-phalcon-install-devtools"
Had to remove ".php" at line 14 because the file doesn't have it
It installs it correctly now.